### PR TITLE
Replace irrelevant references to POSIX shell with Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ EN Version available in: PHAINO-ENG.TXT
 
 Russian version:
 
-`sh -c "$(curl -fsSL https://raw.github.com/Whiletruedoend/phainocode/master/phainocode-ru.sh)"`
+`bash -c "$(curl -fsSL https://raw.github.com/Whiletruedoend/phainocode/master/phainocode-ru.sh)"`
 
 English version:
 
-`sh -c "$(curl -fsSL https://raw.github.com/Whiletruedoend/phainocode/master/phainocode.sh)"`
+`bash -c "$(curl -fsSL https://raw.github.com/Whiletruedoend/phainocode/master/phainocode.sh)"`
 
 ## Contact
 Feel free to contact me about ideas or code implementation:

--- a/phainocode-ru.sh
+++ b/phainocode-ru.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 clear
 

--- a/phainocode.sh
+++ b/phainocode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 clear
 


### PR DESCRIPTION
This implementation is not compatible with /bin/sh, and the command suggested in the README fails unless /bin/sh is symlinked to /bin/bash.